### PR TITLE
Better `span.markdown-embed` parity with native Obisidan print to pdf

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -206,9 +206,16 @@ export class ExportConfigModal extends Modal {
         document.body.innerHTML = decodeURIComponent(\`${encodeURIComponent(this.doc.body.innerHTML)}\`);
         document.head.innerHTML = decodeURIComponent(\`${encodeURIComponent(document.head.innerHTML)}\`);
 
+				function atob_utf8(string) { 
+          const latin = atob(string); 
+          return new TextDecoder('utf-8').decode(
+            Uint8Array.from({ length: latin.length },(_, index) => latin.charCodeAt(index))
+          ) 
+        }
+
 		    function decodeBase64(encodedString) {
           try {
-            return atob(encodedString);
+            return atob_utf8(encodedString);
           } catch (e) {
             // If atob fails, it's likely not base64 encoded, so return the original string
             return encodedString;

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -205,7 +205,33 @@ export class ExportConfigModal extends Modal {
         await this.preview.executeJavaScript(`
         document.body.innerHTML = decodeURIComponent(\`${encodeURIComponent(this.doc.body.innerHTML)}\`);
         document.head.innerHTML = decodeURIComponent(\`${encodeURIComponent(document.head.innerHTML)}\`);
-				
+
+		    function decodeBase64(encodedString) {
+          try {
+            return atob(encodedString);
+          } catch (e) {
+            // If atob fails, it's likely not base64 encoded, so return the original string
+            return encodedString;
+          }
+        }
+        
+        // Function to recursively decode and replace innerHTML of span.markdown-embed elements
+        function decodeAndReplaceEmbed(element) {
+          if (element.classList.contains("markdown-embed")) {
+            // Decode the innerHTML
+            const decodedContent = decodeBase64(element.innerHTML);
+            // Replace the innerHTML with the decoded content
+            element.innerHTML = decodedContent;
+            // Check if the new content contains further span.markdown-embed elements
+            const newEmbeds = element.querySelectorAll("span.markdown-embed");
+            newEmbeds.forEach(decodeAndReplaceEmbed);
+          }
+        }
+        
+        // Start the process with all span.markdown-embed elements in the document
+        const spans = document.querySelectorAll("span.markdown-embed");
+        spans.forEach(decodeAndReplaceEmbed);
+
         document.body.setAttribute("class", \`${document.body.getAttribute("class")}\`)
         document.body.setAttribute("style", \`${document.body.getAttribute("style")}\`)
         document.body.addClass("theme-light");

--- a/src/render.ts
+++ b/src/render.ts
@@ -228,21 +228,14 @@ export async function renderMarkdown(
 export function fixDoc(doc: Document, title: string) {
   const dest = modifyDest(doc);
   fixAnchors(doc, dest, title);
-  fixEmbedSpan(doc);
+  encodeEmbeds(doc);
 }
 
-export function fixEmbedSpan(doc: Document) {
-  const spans = doc.querySelectorAll("span.markdown-embed");
+export function encodeEmbeds(doc: Document) {
 
-  spans.forEach((span: HTMLElement) => {
-    const newDiv = document.createElement("div");
+  const spans = [...doc.querySelectorAll("span.markdown-embed")].reverse();
+  spans.forEach((span: HTMLElement) => span.innerHTML = btoa(span.innerHTML));  
 
-    copyAttributes(newDiv, span.attributes);
-
-    newDiv.innerHTML = span.innerHTML;
-
-    span.parentNode?.replaceChild(newDiv, span);
-  });
 }
 
 export async function fixWaitRender(data: string, viewEl: HTMLElement) {

--- a/src/render.ts
+++ b/src/render.ts
@@ -234,8 +234,12 @@ export function fixDoc(doc: Document, title: string) {
 export function encodeEmbeds(doc: Document) {
 
   const spans = [...doc.querySelectorAll("span.markdown-embed")].reverse();
-  spans.forEach((span: HTMLElement) => span.innerHTML = btoa(span.innerHTML));  
+  spans.forEach((span: HTMLElement) => span.innerHTML = btoa_utf8(span.innerHTML));  
 
+}
+
+function btoa_utf8(string) { 
+  return btoa( String.fromCharCode( ...new TextEncoder('utf-8').encode(string))) 
 }
 
 export async function fixWaitRender(data: string, viewEl: HTMLElement) {


### PR DESCRIPTION
This took a while to track down, after noticing my `@media print { ... }` css files where rendering differently using your plugin compared to Obsidian's native print functionality.

## Issue: broken block contexts

A better (but still not ideal) solution to have `span.markdown-embeds` behave similarly to native Obsidian, requires nested block-level elements to be inserted *after* the document.body.innerHTML has been set in [line 206](https://github.com/l1xnan/obsidian-better-export-pdf/blob/16229e564fd85a0c3a7764f8ed905e708aba8784/src/modal.ts#L206). Namely, certain block level elements (divs, blockquotes, etc.) force a break in the block context of a parent element (most notably [`<p>`](https://www.w3.org/TR/html401/struct/text.html#h-9.3.1:~:text=The%20P%20element%20represents%20a%20paragraph.%20It%20cannot%20contain%20block%2Dlevel%20elements%20(including%20P%20itself).)) which messes up the resulting HTML if set using `document.body.innerHTML`:

``` html
<p>
  Hello
  <span class="internal-embed">
    <div>broken</div>
  </span>
  world
</p>
```
Leads to the following output with orphaned nodes when parsed by `.innerHTML`:

``` html
<p>
  Hello
  <span class="internal-embed"></span>
</p>
<div>broken</div>
world
<p></p>
```

A possible solution is base64 encoding the content of `span.markdown-embed` elements starting from the last element by changing

https://github.com/l1xnan/obsidian-better-export-pdf/blob/16229e564fd85a0c3a7764f8ed905e708aba8784/src/render.ts#L234-L246

to this [encoding function](https://github.com/dleeftink/obsidian-better-export-pdf/blob/9ce11738c58573dcdf2c9e7fab3969baf028fd57/src/render.ts#L234-L239) and then recursively decoding the base64 encoded elements after `document.body.innerHTML` has been set:

https://github.com/l1xnan/obsidian-better-export-pdf/blob/16229e564fd85a0c3a7764f8ed905e708aba8784/src/modal.ts#L206

using this [decoding function](https://github.com/dleeftink/obsidian-better-export-pdf/blob/9ce11738c58573dcdf2c9e7fab3969baf028fd57/src/modal.ts#L219-L220).

## Workaround

This workaround maintains nested block level elements without forcing breaks in the block context of the parent element and messing up the layout. The following functions are added

1. `encodeEmbeds(doc)`

    - Starts from the last element using `[...document.querySelectorAll('span.markdown-embeds')].reverse()`;
    - Encodes the innerHTML of `span.markdown-embed` elements using `span.innerHTML = btoa(span.innerHTML)`

2. `decodeAndReplaceEmbed(element)`

    - Utility within the `appendWebview` function
    - Decodes the innerHTML of `span.markdown-embeds` recursively

## <??>

**Note**: the `encodeEmbeds(doc)` function may need to be rewritten to encode the deepest nested (sibling) elements first instead of starting with the last element. However, simply reversing the order of iteration seems fine in my testing, as deeply nested elements always come later when selected using `document.querySelectorAll()`.