### PR TITLE
Fixes Canvas to Image Conversion Clipping

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -69,6 +69,11 @@ body {
     break-after: auto;
   }
 }
+
+img.__canvas__ {
+  width: 100% !important;
+  height: 100% !important;
+}
 `;
 
 export function getPatchStyle() {


### PR DESCRIPTION
When converting a canvas to an image it would clip the image. As a fix we can override the width and height to 100%.

# Issue
While displaying charts through dataviewjs code block, my graphs were getting clipped when exporting to PDF.

OS: Arch Linux

## DataviewJS Block
```dataviewjs
await dv.view("views/daily-note-doughnut", {
	container: this.container 
});
```

## DataviewJS View
```js
function dailyNoteDoughnut(args){
	if(!args.container){ throw new Error("Container is Required!"); }

	args.folder ??= dv.current().file.folder;
	args.completedStatus ??= ["x"];
	args.incompleteStatus ??= [" ", "/"];
	args.doughnutLables ??= ["Completed", "Incompleted"];
	args.completedColor ??= "rgb(0,255,0)";
	args.incompleteColor ??= "rgb(255,0,0)";
	args.width ??= "50%";

	args.taskFilter ??= function(page){
		return page.file.name !== dv.current().file.name && page?.tags?.includes?.("daily-spread")
	};

	let dailyNoteTasks = dv.pages(`"${args.folder}"`).filter(p => args.taskFilter);
	let incompletedTasks = dailyNoteTasks.file.tasks.where(t => args.incompleteStatus.includes(t.status));
	let completedTasks = dailyNoteTasks.file.tasks.where(t => args.completedStatus.includes(t.status));
	window.renderChart({
		width: args.width,
		chartOptions:{
			type: 'doughnut',
			data: {
				labels: args.doughnutLables,
				datasets: [{
					data: [completedTasks.length, incompletedTasks.length],
					backgroundColor: [args.completedColor, args.incompletedColor]
				}],
			}
		}
	}, args.container);
}
dailyNoteDoughnut(input)
```

## Obsidian Result

![image](https://github.com/user-attachments/assets/65bfa32e-21c1-47e6-8840-0687e9376bd5)

## Better Export PDF Preview Result

![image](https://github.com/user-attachments/assets/c8e3cc70-6616-435b-8384-187a71da5c0a)

## PDF Export Result

![image](https://github.com/user-attachments/assets/ffc4f635-0280-4157-b18a-75878f0164db)


# Fixes
After debugging I noticed that the image was using fixed pixels on the style width and height. What my changes did was to set the width and height to be 100%. 

## After Changes Better Export PDF Preview Result

![image](https://github.com/user-attachments/assets/9a426581-4322-4edc-b3f8-71efaf1a8901)

## After Changes PDF Export Result

![image](https://github.com/user-attachments/assets/a1a427c8-566d-4c60-8bdc-7aaa1971e385)
