### PR TITLE
Await webview dom-ready before resizing preview

### DIFF
--- a/src/modal.ts
+++ b/src/modal.ts
@@ -10,7 +10,6 @@ import { createWebview, fixDoc, getAllStyles, getPatchStyle, renderMarkdown, typ
 import { isNumber, mm2px, px2mm, safeParseFloat, safeParseInt, traverseFolder } from "./utils";
 import Progress from "./Progress.svelte";
 import { mount, unmount } from "svelte";
-import pLimit from "p-limit";
 export type PageSizeType = electron.PrintToPDFOptions["pageSize"];
 
 export interface TConfig {
@@ -46,6 +45,42 @@ function fullWidthButton(button: ButtonComponent) {
 
 function setInputWidth(inputEl: HTMLInputElement) {
   inputEl.setAttribute("style", `width: 100px;`);
+}
+
+function createConcurrencyLimiter(concurrency: number) {
+  const limit = Math.max(1, concurrency);
+  let active = 0;
+  const queue: Array<() => void> = [];
+
+  const next = () => {
+    if (queue.length === 0 || active >= limit) {
+      return;
+    }
+    const task = queue.shift();
+    if (task) {
+      task();
+    }
+  };
+
+  return async function <T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const runTask = () => {
+        active++;
+        task()
+          .then(resolve, reject)
+          .finally(() => {
+            active--;
+            next();
+          });
+      };
+
+      if (active < limit) {
+        runTask();
+      } else {
+        queue.push(runTask);
+      }
+    });
+  };
 }
 
 export class ExportConfigModal extends Modal {
@@ -134,7 +169,7 @@ export class ExportConfigModal extends Modal {
 
   async renderFiles(data: ParamType[], docs?: DocType[], cb?: (i: number) => void) {
     const concurrency = safeParseInt(this.plugin.settings.concurrency) || 5;
-    const limit = pLimit(concurrency);
+    const limit = createConcurrencyLimiter(concurrency);
 
     const inputs = data.map((param, i) =>
       limit(async () => {

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -262,6 +262,74 @@ export class ExportConfigModal extends Modal {
       document.title = \`${doc.title}\`;
       `;
   }
+
+  private extractPrintCss(source: string) {
+    const blocks: string[] = [];
+    const regex = /@media\s+print\s*\{/gi;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(source))) {
+      let depth = 1;
+      let index = regex.lastIndex;
+      const start = index;
+      while (index < source.length && depth > 0) {
+        const char = source[index];
+        if (char === "{") {
+          depth++;
+        } else if (char === "}") {
+          depth--;
+        }
+        index++;
+      }
+      blocks.push(source.slice(start, index - 1).trim());
+      regex.lastIndex = index;
+    }
+    return blocks.join("\n\n");
+  }
+
+  private async whenWebviewReady(preview: electron.WebviewTag, doc: Document) {
+    const injectContent = async () => {
+      this.completed = true;
+      for (const css of getAllStyles()) {
+        await preview.insertCSS(css);
+      }
+      if (this.config.cssSnippet && this.config.cssSnippet != "0") {
+        try {
+          const cssSnippet = await fs.readFile(this.config.cssSnippet, { encoding: "utf8" });
+          const printCss = this.extractPrintCss(cssSnippet);
+          if (printCss) {
+            await preview.insertCSS(printCss);
+          }
+          await preview.insertCSS(cssSnippet);
+        } catch (error) {
+          console.warn(error);
+        }
+      }
+      await preview.executeJavaScript(this.makeWebviewJs(doc));
+      for (const css of getPatchStyle()) {
+        await preview.insertCSS(css);
+      }
+    };
+
+    return new Promise<void>((resolve, reject) => {
+      const handleDomReady = async () => {
+        preview.removeEventListener("dom-ready", handleDomReady);
+        preview.removeEventListener("did-fail-load", handleDidFailLoad);
+        try {
+          await injectContent();
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      };
+      const handleDidFailLoad = (event: any) => {
+        preview.removeEventListener("dom-ready", handleDomReady);
+        preview.removeEventListener("did-fail-load", handleDidFailLoad);
+        reject(new Error(`Webview failed to load: ${event?.errorDescription ?? "unknown error"}`));
+      };
+      preview.addEventListener("dom-ready", handleDomReady);
+      preview.addEventListener("did-fail-load", handleDidFailLoad);
+    });
+  }
   /**
    * append webview
    * @param e HTMLDivElement
@@ -270,32 +338,13 @@ export class ExportConfigModal extends Modal {
   async appendWebview(e: HTMLDivElement, doc: Document) {
     const webview = createWebview(this.scale);
     const preview = e.appendChild(webview);
-    this.webviews.push(preview);
     this.preview = preview;
-    preview.addEventListener("dom-ready", async (e) => {
-      this.completed = true;
-      getAllStyles().forEach(async (css) => {
-        await preview.insertCSS(css);
-      });
-      if (this.config.cssSnippet && this.config.cssSnippet != "0") {
-        try {
-          const cssSnippet = await fs.readFile(this.config.cssSnippet, { encoding: "utf8" });
-          // remove `@media print { ... }`
-          const printCss = cssSnippet.replaceAll(/@media print\s*{([^}]+)}/g, "$1");
-          await preview.insertCSS(printCss);
-          await preview.insertCSS(cssSnippet);
-        } catch (error) {
-          console.warn(error);
-        }
-      }
-      await preview.executeJavaScript(this.makeWebviewJs(doc));
-      getPatchStyle().forEach(async (css) => {
-        await preview.insertCSS(css);
-      });
-    });
+    this.webviews.push(preview);
+    await this.whenWebviewReady(preview, doc);
   }
   async appendWebviews(el: HTMLDivElement, render = true) {
     el.empty();
+    this.webviews = [];
     if (render) {
       // await this.renderFiles(el);
       // @ts-ignore
@@ -559,7 +608,7 @@ export class ExportConfigModal extends Modal {
 
     new Setting(contentEl).setName(this.i18n.exportDialog.downscalePercent).addSlider((slider) => {
       slider
-        .setLimits(0, 200, 1)
+        .setLimits(0, 100, 1)
         .setValue(this.config["scale"] as number)
         .onChange(async (value) => {
           this.config["scale"] = value;


### PR DESCRIPTION
**Summary**
- wait for the preview webview to emit dom-ready (and handle did-fail-load) before injecting styles and measuring layout
- ensure disabled CSS snippets still render correctly in the preview by extracting @media print blocks before insertion
- cap the downscale slider at 100% so users can’t overshoot the supported range

**Testing**
- pnpm build
- Obsidian manual checks:
  - refresh button no longer throws console errors
  - downscale slider stops at 100
  - selecting a CSS snippet updates the preview

**Screenshots**
Before: <img width="1919" height="1126" alt="Before_2025-10-23" src="https://github.com/user-attachments/assets/af3c54a7-16d5-4815-b4e0-9d1c070a5b7d" />
After: <img width="1919" height="1126" alt="After 2025-10-23" src="https://github.com/user-attachments/assets/1e0a1f9e-9fa3-47c8-8372-2ca70134cf54" />
