### PR TITLE
feat: add skipFirstPageHeader option

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,6 +8,7 @@ export default {
     downscalePercent: "Downscale Percent",
     landscape: "Landscape",
     displayHeader: "Display Header",
+    skipFirstPageHeader: "Skip header on first page",
     displayFooter: "Display Footer",
     openAfterExport: "Open after export",
     cssSnippets: "CSS snippets",
@@ -15,6 +16,7 @@ export default {
   settings: {
     showTitle: "Add file name as title",
     displayHeader: "Display headers",
+    skipFirstPageHeader: "Skip header on first page",
     displayFooter: "Display footer",
     printBackground: "Print background",
     maxLevel: "Max headings level of the outline",

--- a/src/i18n/zh.ts
+++ b/src/i18n/zh.ts
@@ -11,6 +11,7 @@ export default {
     downscalePercent: "缩放",
     landscape: "横向打印",
     displayHeader: "页眉",
+    skipFirstPageHeader: "跳过首页页眉",
     displayFooter: "页脚",
     openAfterExport: "导出后打开",
     cssSnippets: "CSS代码片段",
@@ -19,6 +20,7 @@ export default {
   settings: {
     showTitle: "将笔记名作为标题",
     displayHeader: "显示页眉",
+    skipFirstPageHeader: "跳过首页页眉",
     displayFooter: "显示页脚",
     printBackground: "打印背景",
     maxLevel: "最大标题级别",

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ export interface BetterExportPdfPluginSettings {
   maxLevel: string;
 
   displayHeader: boolean;
+  skipFirstPageHeader: boolean;
   displayFooter: boolean;
   headerTemplate: string;
   footerTemplate: string;
@@ -35,6 +36,7 @@ const DEFAULT_SETTINGS: BetterExportPdfPluginSettings = {
   maxLevel: "6",
 
   displayHeader: true,
+  skipFirstPageHeader: false,
   displayFooter: true,
   headerTemplate: `<div style="width: 100vw;font-size:10px;text-align:center;"><span class="title"></span></div>`,
   footerTemplate: `<div style="width: 100vw;font-size:10px;text-align:center;"><span class="pageNumber"></span> / <span class="totalPages"></span></div>`,

--- a/src/modal.ts
+++ b/src/modal.ts
@@ -24,6 +24,7 @@ export interface TConfig {
   scale: number;
   showTitle: boolean;
   displayHeader: boolean;
+  skipFirstPageHeader: boolean;
   displayFooter: boolean;
 
   marginTop?: string;
@@ -91,6 +92,7 @@ export class ExportConfigModal extends Modal {
       marginLeft: "10",
       marginRight: "10",
       displayHeader: plugin.settings.displayHeader ?? true,
+      skipFirstPageHeader: plugin.settings.skipFirstPageHeader ?? false,
       displayFooter: plugin.settings.displayHeader ?? true,
       cssSnippet: "0",
       ...(plugin.settings?.prevConfig ?? {}),
@@ -581,6 +583,15 @@ export class ExportConfigModal extends Modal {
         .setValue(this.config["displayHeader"])
         .onChange(async (value) => {
           this.config["displayHeader"] = value;
+        }),
+    );
+
+    new Setting(contentEl).setName(this.i18n.exportDialog.skipFirstPageHeader).addToggle((toggle) =>
+      toggle
+        .setTooltip("Hide header on first page")
+        .setValue(this.config["skipFirstPageHeader"] ?? false)
+        .onChange(async (value) => {
+          this.config["skipFirstPageHeader"] = value;
         }),
     );
 

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -434,7 +434,20 @@ export async function exportToPDF(
   }
 
   try {
-    let data = await w.printToPDF(printOptions);
+    let data: Uint8Array;
+    if (config["skipFirstPageHeader"] && config["displayHeader"]) {
+      // Two-pass merge: print twice, replace page 1 with a headerless version
+      const fullData = await w.printToPDF(printOptions);
+      const noHdrData = await w.printToPDF({ ...printOptions, headerTemplate: "<span></span>" });
+      const fullPdf = await PDFDocument.load(fullData);
+      const noHdrPdf = await PDFDocument.load(noHdrData);
+      const [cleanPage] = await fullPdf.copyPages(noHdrPdf, [0]);
+      fullPdf.removePage(0);
+      fullPdf.insertPage(0, cleanPage);
+      data = await fullPdf.save();
+    } else {
+      data = await w.printToPDF(printOptions);
+    }
 
     data = await editPDF(data, {
       headings: getHeadingTree(doc),

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -59,6 +59,18 @@ export default class ConfigSettingTab extends PluginSettingTab {
           this.plugin.saveSettings();
         }),
     );
+    new Setting(containerEl)
+      .setName(this.i18n.settings.skipFirstPageHeader)
+      .setDesc("Hide the header on the first page (header appears on all subsequent pages)")
+      .addToggle((toggle) =>
+        toggle
+          .setTooltip("Hide header on first page")
+          .setValue(this.plugin.settings.skipFirstPageHeader ?? false)
+          .onChange(async (value) => {
+            this.plugin.settings.skipFirstPageHeader = value;
+            this.plugin.saveSettings();
+          }),
+      );
     new Setting(containerEl).setName(this.i18n.settings.displayFooter).addToggle((toggle) =>
       toggle
         .setTooltip("Display footer")


### PR DESCRIPTION
## Summary

- Adds a **Skip header on first page** toggle to both the export dialog and the plugin settings
- When enabled alongside **Display Header**, the header is suppressed on page 1 and shown on all subsequent pages
- Default value is `false` (no behaviour change for existing users)

## How it works

Two `printToPDF` passes are performed:
1. Full document with the configured header template
2. Full document with an empty header template (`<span></span>`)

`pdf-lib` (already bundled) is then used to replace page 0 of the first render
with page 0 from the second render — a single PDF where only page 1 lacks a header.

**Why not `pageRanges`?** Electron's `printToPDF` does not reliably support the
`pageRanges` option, so the two-pass merge is used instead.

## Files changed

- `src/i18n/en.ts` / `src/i18n/zh.ts` — label strings
- `src/main.ts` — `BetterExportPdfPluginSettings` interface + `DEFAULT_SETTINGS`
- `src/modal.ts` — `TConfig` type + export dialog toggle + default config initialisation
- `src/setting.ts` — settings page toggle
- `src/pdf.ts` — two-pass PDF merge logic
