### PR TITLE
fix: handle webview did-fail-load so the preview cannot hang

### DIFF
--- a/src/components/PdfPreview.svelte
+++ b/src/components/PdfPreview.svelte
@@ -156,6 +156,17 @@
   function initWebviewEvents(preview: electron.WebviewTag, docObj: any) {
     webviews.push(preview);
 
+    // Ensure the doc promise is settled exactly once so a failed load
+    // cannot leave renderPreview's Promise.all waiting forever.
+    let settled = false;
+    const unblock = () => {
+      if (settled) return;
+      settled = true;
+      preview.removeEventListener("dom-ready", handler);
+      preview.removeEventListener("did-fail-load", failHandler);
+      docObj.resolve?.();
+    };
+
     const handler = async () => {
       completed = true;
       getAllStyles().forEach(async (css) => {
@@ -175,16 +186,23 @@
       getPatchStyle().forEach(async (css) => {
         await preview.insertCSS(css);
       });
-      if (docObj.resolve) {
-        docObj.resolve();
-      }
+      unblock();
+    };
+
+    const failHandler = (event: any) => {
+      // -3 is ERR_ABORTED, which fires on benign in-page navigations; ignore it.
+      if (event?.errorCode === -3) return;
+      console.warn(`Webview failed to load: ${event?.errorDescription ?? "unknown error"}`);
+      unblock();
     };
 
     preview.addEventListener("dom-ready", handler);
+    preview.addEventListener("did-fail-load", failHandler);
 
     return {
       destroy() {
         preview.removeEventListener("dom-ready", handler);
+        preview.removeEventListener("did-fail-load", failHandler);
       },
     };
   }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,5 +1,3 @@
-import { version } from "node:os";
-
 export default {
   exportCurrentFile: "Export current file to PDF",
   exportCurrentFileWithPrevious: "Export to PDF with previous Settings",


### PR DESCRIPTION
## Summary

The v1 preview (`PdfPreview.svelte`) resolves a per-document promise inside the webview `dom-ready` handler, and `renderPreview` awaits `Promise.all` of those promises before measuring layout. If a webview emits `did-fail-load` instead of `dom-ready`, that promise never settles and the preview hangs.

This PR listens for `did-fail-load` alongside `dom-ready` and settles the promise exactly once through a shared guard, removing both listeners on either outcome. `ERR_ABORTED` (`-3`) is ignored because it fires on benign in-page navigations.

It also removes an unused `import { version } from "node:os"` in `src/i18n/en.ts` that breaks the esbuild bundle on current `master` (newer esbuild does not externalize the `node:`-prefixed builtin, and the symbol was never referenced).

## Context

This is the standalone successor to #418, rebased onto the 2.0.0-beta.1 architecture. The other two changes #418 proposed are already present in 2.0:

- awaiting `dom-ready` before injecting styles and measuring layout, and
- extracting `@media print` blocks from disabled CSS snippets before insertion.

So only the `did-fail-load` robustness piece remained, which is what this PR adds. #418 will be closed in favor of this.

## Testing

- `node esbuild.config.mjs production` builds and the bundle includes the `did-fail-load` handling.
- The pre-existing `tsc -noEmit` errors on `master` are unrelated to this change (identical on a clean checkout).
- Manual Obsidian check still recommended: force a webview load failure and confirm the preview no longer hangs.
