### PR TITLE
fix: use frontmatter `title` in PDF header instead of filename

### DIFF
--- a/src/components/PdfPreviewV2.svelte
+++ b/src/components/PdfPreviewV2.svelte
@@ -200,8 +200,8 @@
     });
 
     for (const [i, outfile] of outfiles.entries()) {
-      const { doc, file } = docs[i] as { doc: HTMLDivElement; file: TFile };
-      const title = file.basename;
+      const { doc, file, frontMatter } = docs[i] as { doc: HTMLDivElement; file: TFile; frontMatter: Record<string, unknown> };
+      const title = (frontMatter?.title as string | undefined) ?? file.basename;
       doc.style.display = "block";
       await sleep(200);
 


### PR DESCRIPTION
## Problem

When a note has a `title` property in its YAML frontmatter, the `<span class="title">` in the header/footer template still shows the **filename** instead of the frontmatter title.

**Example:**
- File: `my-quarterly-report.md`
- Frontmatter: `title: "Q3 2025 — Quarterly Report"`
- **Expected** in header: `Q3 2025 — Quarterly Report`
- **Actual** in header: `my-quarterly-report`

## Root cause

In `PdfPreviewV2.svelte`, the export loop sets:

```ts
// before
const { doc, file } = docs[i];
const title = file.basename;   // ← always the filename
await exportToPDF({ el: doc, outputFile: outfile, title, onlyPreview });
```

`exportToPDF` then sets `document.title = title`, and Chromium's print API injects `document.title` into every `<span class="title">` element in the header/footer template.

This hardcoded `file.basename` wins over `frontMatter?.title` even though `render.ts` already resolves the title with the correct priority chain:

```ts
const title = extra?.title ?? frontMatter?.title ?? file.basename;
```

## Fix

Destructure `frontMatter` from the `DocType` entry (it is already present on the type) and apply the same `frontMatter.title ?? file.basename` fallback in the export loop:

```ts
// after
const { doc, file, frontMatter } = docs[i] as { doc: HTMLDivElement; file: TFile; frontMatter: Record<string, unknown> };
const title = (frontMatter?.title as string | undefined) ?? file.basename;
```

## Notes

- **Non-breaking**: only affects notes with an explicit `title` key in YAML frontmatter. All other notes continue using the filename as before.
- `PdfPreview.svelte` (v1 engine) is not affected — it passes the full `DocType` (including `frontMatter`) directly to `exportToPDF`, which relies on `render.ts`'s resolution.
- The output **filename** in the save dialog is not changed (still uses `file.basename`, which is the correct behaviour).